### PR TITLE
Show help message when no subcommands are provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 /*.xcodeproj
 xcuserdata/
 DerivedData/
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm/
+.vscode/
+Package.resolved

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -33,7 +33,10 @@ public struct Swiftly: SwiftlyCommand {
 
     public init() {}
 
-    public mutating func run() async throws {}
+    public mutating func run() async throws {
+        // Workaround for https://github.com/apple/swift-argument-parser/issues/563
+        throw Error(message: "No subcommands provided. See 'swiftly --help' for more information.")
+    }
 
 #if os(Linux)
     internal static let currentPlatform = Linux.currentPlatform

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -9,7 +9,7 @@ import SwiftlyCore
 @available(macOS 10.15, *)
 public struct Swiftly: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
-        abstract: "A utility for insalling and managing Swift toolchains.",
+        abstract: "A utility for installing and managing Swift toolchains.",
 
         version: "0.1.0",
 
@@ -32,11 +32,6 @@ public struct Swiftly: SwiftlyCommand {
     }
 
     public init() {}
-
-    public mutating func run() async throws {
-        // Workaround for https://github.com/apple/swift-argument-parser/issues/563
-        throw Error(message: "No subcommands provided. See 'swiftly --help' for more information.")
-    }
 
 #if os(Linux)
     internal static let currentPlatform = Linux.currentPlatform


### PR DESCRIPTION
Resolves #38.
~~Also see https://github.com/apple/swift-argument-parser/issues/563.~~ Thanks to Nate Cook for the response.

Quoting:
> `ParsableCommand` types provide this behavior (printing help by default) through the default implementation of the `run()` method. Since the `swiftly` command provides [an empty implementation](https://github.com/swift-server/swiftly/blob/main/Sources/Swiftly/Swiftly.swift#L36), that isn't done. You can either remove that implementation or print the result of `Swiftly.helpMessage()` from within that method.

### Current Behavior
```bash
# swift run swiftly
Building for debugging...
Build complete! (0.50s)
```

### After this PR
```bash
# swift run swiftly
Building for debugging...
Build complete! (0.50s)
OVERVIEW: A utility for installing and managing Swift toolchains.

USAGE: swiftly <subcommand>

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.

SUBCOMMANDS:
  install                 Install a new toolchain.
  use                     Set the active toolchain.
  uninstall               Remove an installed toolchain.
  list                    List installed toolchains.

  See 'swiftly help <subcommand>' for detailed help.
```