### PR TITLE
`swiftly` installer change default bin to `/usr/local/bin`

### DIFF
--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -67,13 +67,11 @@ extension Platform {
     ///
     /// If a mocked home directory is set, this will be the "bin" subdirectory of the home directory.
     /// If not, this will be the SWIFTLY_BIN_DIR environment variable if set. If that's also unset,
-    /// this will default to ~/.local/bin.
+    /// this will default to /usr/local/bin.
     public var swiftlyBinDir: URL {
-        SwiftlyCore.mockedHomeDir.map { $0.appendingPathComponent("bin", isDirectory: true) }
-            ?? ProcessInfo.processInfo.environment["SWIFTLY_BIN_DIR"].map { URL(fileURLWithPath: $0) }
-            ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local", isDirectory: true)
-            .appendingPathComponent("bin", isDirectory: true)
+        SwiftlyCore.mockedHomeDir.map { $0.appendingPathComponent("bin", isDirectory: true) } ??
+          ProcessInfo.processInfo.environment["SWIFTLY_BIN_DIR"].map { URL(fileURLWithPath: $0) } ?? 
+          URL(fileURLWithPath: "/usr/local/bin")
     }
 
     /// The "toolchains" subdirectory of swiftly's home directory. Contains the Swift toolchains managed by swiftly.

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -4,7 +4,7 @@
 # Script used to install and configure swiftly.
 # 
 # This script will download the latest released swiftly executable and install it
-# to $SWIFTLY_BIN_DIR, or ~/.local/bin if that variable isn't specified.
+# to $SWIFTLY_BIN_DIR, or /usr/local/bin if that variable isn't specified.
 #
 # This script will also create a directory at $SWIFTLY_HOME_DIR, or
 # $XDG_DATA_HOME/swiftly if that variable isn't specified. If XDG_DATA_HOME is also unset,
@@ -30,10 +30,6 @@ read_input_with_default () {
     if [ -z "$READ_INPUT_RETURN" ]; then
         READ_INPUT_RETURN="$1"
     fi
-}
-
-in_path() {
-  [[ ":$PATH:" == *":$1:"* ]]
 }
 
 SWIFTLY_INSTALL_VERSION="0.1.0"
@@ -165,12 +161,7 @@ echo ""
 DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 DEFAULT_HOME_DIR="$DATA_DIR/swiftly"
 HOME_DIR="${SWIFTLY_HOME_DIR:-$DEFAULT_HOME_DIR}"
-DEFAULT_BIN_DIR="$HOME/.local/bin"
-
-if ! in_path "$HOME/.local/bin" && in_path "/usr/local/bin"; then
-    DEFAULT_BIN_DIR="/usr/local/bin"
-fi
-
+DEFAULT_BIN_DIR="/usr/local/bin"
 BIN_DIR="${SWIFTLY_BIN_DIR:-$DEFAULT_BIN_DIR}"
 
 while [ -z "$DISABLE_CONFIRMATION" ]; do

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -32,6 +32,10 @@ read_input_with_default () {
     fi
 }
 
+in_path() {
+  [[ ":$PATH:" == *":$1:"* ]]
+}
+
 SWIFTLY_INSTALL_VERSION="0.1.0"
 
 for arg in "$@"; do
@@ -162,6 +166,11 @@ DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 DEFAULT_HOME_DIR="$DATA_DIR/swiftly"
 HOME_DIR="${SWIFTLY_HOME_DIR:-$DEFAULT_HOME_DIR}"
 DEFAULT_BIN_DIR="$HOME/.local/bin"
+
+if ! in_path "$HOME/.local/bin" && in_path "/usr/local/bin"; then
+    DEFAULT_BIN_DIR="/usr/local/bin"
+fi
+
 BIN_DIR="${SWIFTLY_BIN_DIR:-$DEFAULT_BIN_DIR}"
 
 while [ -z "$DISABLE_CONFIRMATION" ]; do


### PR DESCRIPTION
Using the changes in this PR, swiftly and its installer will default to `/usr/local/bin` instead of `$HOME/.local/bin`.

I was initially going to do [this](https://github.com/swift-server/swiftly/issues/48#issuecomment-1500279519), but ended up doing this after some more research.

I personally checked 6 different OS instances, (my MacBook + Ubuntu 22.04 & 18.04 & amazonlinux on Docker + Ubuntu 22.04 on 2 vps, one with root and one with a default user). None of them actually had `$HOME/.local/bin` in their PATH and all of them had `/usr/local/bin` (Not even the 2 non-root-user OS: my MacBook and a vps).

I did find this [Github Issue](https://github.com/JuliaLang/juliaup/issues/247) that mentions there should be a `$HOME/.local/bin`, but I just don't see it. Overall i'm a little bit confused of the PATH situation, but I think `/usr/local/bin` should solve the problem anyway.

The [bash docs](https://git.savannah.gnu.org/cgit/bash.git/tree/doc/bash.1?h=f188aa6a013e89d421e39354086eed513652b492#n2501) says this about PATH:
> .B PATH
indicates the current directory.
A null directory name may appear as two adjacent colons, or as an initial
or trailing colon.
The default path is system-dependent,
and is set by the administrator who installs
.BR bash .
A common value is
.na
.if t \f(CW/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin\fP.
.if n ``/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin''.

This, plus my own observations, makes me think we can put some trust in `/usr/local/bin`.

Solves #48.