### PR TITLE
Install system dependencies in swiflty-install.sh

### DIFF
--- a/docker/install-test.dockerfile
+++ b/docker/install-test.dockerfile
@@ -8,5 +8,5 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # dependencies
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update --fix-missing && apt-get install -y curl
 RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.profile

--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -13,7 +13,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # dependencies
-RUN apt-get update && apt-get install -y curl build-essential
+RUN apt-get update --fix-missing && apt-get install -y curl build-essential
 COPY ./scripts/install-libarchive.sh /
 RUN /install-libarchive.sh
 

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -164,6 +164,12 @@ install_system_deps () {
     else
         sudo "$package_manager" install "${install_args[@]}" "${package_list[@]}"
     fi
+    if [[ "$?" -ne 0 ]]; then
+        echo "System dependency installation failed."
+        if [[ "$package_manager" == "apt-get" ]]; then
+            echo "You may need to run apt-get update before installing system dependencies."
+        fi
+    fi
     set -o errexit
 }
 
@@ -453,6 +459,7 @@ if [[ "$MODIFY_PROFILE" == "true" ]]; then
 fi
 
 if [[ "$SWIFTLY_INSTALL_SYSTEM_DEPS" != "false" ]]; then
+    echo ""
     echo "Installing Swift's system dependencies via $package_manager (note: this may require root access)..."
     install_system_deps
 fi

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -149,7 +149,7 @@ install_system_deps () {
 
     install_args=(--quiet)
     if [[ "$DISABLE_CONFIRMATION" == "true" ]]; then
-        params+=(-y)
+        install_args+=(-y)
     fi
 
     # Disable errexit since failing to install system dependencies is not swiftly installation-fatal.

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -139,10 +139,14 @@ install_system_deps () {
     # This will allow us to return from this function without aborting the entire swiftly installation, even if user just decides not
     # to install dependencies. It also allows user to get confirmation before using sudo, if need be.
 
-    echo "Install Swift's system dependencies using the following command (note: this may require sudo)? (Y/n)"
     echo ""
-    echo "  $package_manager install -q -y ${package_list[@]}"
+    echo "  $package_manager install -q -y \\"
+    printf '    %s' "${package_list[0]}"
+    printf ' \\\n    %s' "${package_list[@]:1}"
+    printf '\n'
     echo ""
+
+    echo "Install Swift's system dependencies using the prior command? (Y/n)"
     read_yn_input "true"
     if [[ "$READ_INPUT_RETURN" != "true" ]]; then
         echo "Skipping system dependencies installation."
@@ -150,15 +154,9 @@ install_system_deps () {
     fi
 
     if [[ "$(id --user)" == "0" ]]; then
-        # if [[ "$package_manager" == "apt-get" ]]; then
-        #     "$package_manager" update
-        # fi
         # "$package_manager" install -q -y "${package_list[@]}"
         echo "ok"
     else
-        # if [[ "$package_manager" == "apt-get" ]]; then
-        #     sudo "$package_manager" update
-        # fi
         # sudo "$package_manager" install -q -y "${package_list[@]}"
         echo "ok"
     fi

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -125,7 +125,7 @@ install_system_deps () {
         echo "Warning: sudo not installed and current user is not root, skipping system dependency installation."
         return
     elif ! has_command "$package_manager" ; then
-        echo "Warning: package manager \"$package_manager\" not found, skipping system dependency instllation."
+        echo "Warning: package manager \"$package_manager\" not found, skipping system dependency installation."
         return
     fi
 

--- a/install/test-util.sh
+++ b/install/test-util.sh
@@ -23,3 +23,52 @@ test_fail () {
 test_pass () {
     exit 0
 }
+
+get_os () {
+    if [[ -f "/etc/os-release" ]]; then
+        OS_RELEASE="/etc/os-release"
+    elif [[ -f "/usr/lib/os-release" ]]; then
+        OS_RELEASE="/usr/lib/os-release"
+    else
+        echo "Error: could not detect OS information"
+        exit 1
+    fi
+
+    source "$OS_RELEASE"
+
+    case "$ID" in
+        "amzn")
+            echo "amazonlinux2"
+            ;;
+
+        "ubuntu")
+            case "$UBUNTU_CODENAME" in
+                "jammy")
+                    echo "ubuntu2204"
+                    ;;
+
+                "focal")
+                    echo "ubuntu2004"
+                    ;;
+
+                "bionic")
+                    echo "ubuntu1804"
+                    ;;
+
+                *)
+                    echo "Unsupported Ubuntu version: $PRETTY_NAME"
+                    exit 1
+                    ;;
+            esac
+            ;;
+
+        "rhel")
+            echo "rhel-ubi9"
+            ;;
+
+        *)
+            echo "Unsupported platform: $PRETTY_NAME"
+            exit 1
+            ;;
+    esac
+}

--- a/install/tests/custom-home-install.sh
+++ b/install/tests/custom-home-install.sh
@@ -18,8 +18,7 @@ cleanup () {
 }
 trap cleanup EXIT
 
-# Make sure that the "~" character is handled properly.
-printf "2\n\$HOME/${CUSTOM_HOME_DIR_NAME}\n\$HOME/${CUSTOM_HOME_DIR_NAME}/bin\ny\n1\n" | ./swiftly-install.sh
+printf "2\n\$HOME/${CUSTOM_HOME_DIR_NAME}\n\$HOME/${CUSTOM_HOME_DIR_NAME}/bin\ny\nn\n1\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH and SWIFTLY_HOME_DIR/SWIFTLY_BIN_DIR.
 bash --login -c "swiftly --version"

--- a/install/tests/custom-install.sh
+++ b/install/tests/custom-install.sh
@@ -24,7 +24,7 @@ cleanup () {
 }
 trap cleanup EXIT
 
-printf "2\n$CUSTOM_HOME_DIR\n$CUSTOM_BIN_DIR\ny\n1\n" | ./swiftly-install.sh
+printf "2\n$CUSTOM_HOME_DIR\n$CUSTOM_BIN_DIR\ny\nn\n1\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH and SWIFTLY_HOME_DIR/SWIFTLY_BIN_DIR.
 bash --login -c "swiftly --version"

--- a/install/tests/custom-tilde-install.sh
+++ b/install/tests/custom-tilde-install.sh
@@ -19,7 +19,7 @@ cleanup () {
 trap cleanup EXIT
 
 # Make sure that the "~" character is handled properly.
-printf "2\n~/${CUSTOM_HOME_DIR_NAME}\n~/${CUSTOM_HOME_DIR_NAME}/bin\ny\n1\n" | ./swiftly-install.sh
+printf "2\n~/${CUSTOM_HOME_DIR_NAME}\n~/${CUSTOM_HOME_DIR_NAME}/bin\ny\nn\n1\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH and SWIFTLY_HOME_DIR/SWIFTLY_BIN_DIR.
 bash --login -c "swiftly --version"

--- a/install/tests/default-install.sh
+++ b/install/tests/default-install.sh
@@ -23,7 +23,7 @@ cleanup () {
 trap cleanup EXIT
 
 if has_command apt-get ; then
-    apt-get remove -y libstdc++-11-dev
+    apt-get remove -y zlib1g-dev
 elif has_command yum ; then
     yum remove -y libcurl-devel
 fi
@@ -44,7 +44,7 @@ if [[ ! -d "$HOME/.local/share/swiftly/toolchains" ]]; then
 fi
 
 if has_command dpkg ; then
-    if ! dpkg --status libstdc++-11-dev ; then
+    if ! dpkg --status zlib1g-dev ; then
         test_fail "System dependencies were not installed properly"
     fi
 elif has_command rpm ; then

--- a/install/tests/default-install.sh
+++ b/install/tests/default-install.sh
@@ -28,7 +28,7 @@ elif has_command yum ; then
     yum remove -y libcurl-devel
 fi
 
-printf "1\ny\n" | ./swiftly-install.sh
+printf "1\ny\n" | DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh
 
 # .profile should be updated to update PATH.
 bash --login -c "swiftly --version"

--- a/install/tests/default-install.sh
+++ b/install/tests/default-install.sh
@@ -22,10 +22,99 @@ cleanup () {
 }
 trap cleanup EXIT
 
+case "$(get_os)" in
+    "ubuntu1804")
+        system_deps=(binutils
+                     git
+                     libc6-dev
+                     libcurl4-openssl-dev
+                     libedit2
+                     libgcc-5-dev
+                     libpython3.6
+                     libstdc++-5-dev
+                     libxml2-dev
+                     pkg-config
+                     tzdata
+                     zip
+                     zlib1g-dev)
+        ;;
+
+    "ubuntu2004")
+        system_deps=(binutils
+                     git
+                     gnupg2
+                     libc6-dev
+                     libcurl4-openssl-dev
+                     libedit2
+                     libgcc-9-dev
+                     libpython3.8
+                     libstdc++-9-dev
+                     libxml2-dev
+                     libz3-dev
+                     pkg-config
+                     tzdata
+                     zip
+                     zlib1g-dev)
+        ;;
+
+    "ubuntu2204")
+        system_deps=(binutils
+                     git
+                     gnupg2
+                     libc6-dev
+                     libcurl4-openssl-dev
+                     libedit2
+                     libgcc-11-dev
+                     libpython3-dev
+                     libstdc++-11-dev
+                     libxml2-dev
+                     libz3-dev
+                     pkg-config
+                     tzdata
+                     zip
+                     zlib1g-dev)
+        ;;
+
+    "amazonlinux2")
+        system_deps=(binutils
+                     gcc
+                     git
+                     glibc-static
+                     libcurl-devel
+                     libedit
+                     libicu
+                     libxml2-devel
+                     tar
+                     unzip
+                     zip
+                     zlib-devel)
+        ;;
+
+    "rhel-ubi9")
+        system_deps=(git
+                     gcc-c++
+                     libcurl-devel
+                     libedit-devel
+                     libuuid-devel
+                     libxml2-devel
+                     ncurses-devel
+                     python3-devel
+                     rsync
+                     sqlite-devel
+                     unzip
+                     zip)
+        ;;
+
+    *)
+        echo "Unrecognized platform"
+        exit 1
+        ;;
+esac
+
 if has_command apt-get ; then
-    apt-get remove -y zlib1g-dev
+    apt-get remove -y "${system_deps[@]}"
 elif has_command yum ; then
-    yum remove -y libcurl-devel
+    yum remove -y "${system_deps[@]}"
 fi
 
 printf "1\ny\n" | DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh
@@ -43,15 +132,19 @@ if [[ ! -d "$HOME/.local/share/swiftly/toolchains" ]]; then
     test_fail "the toolchains directory was not created in SWIFTLY_HOME_DIR"
 fi
 
-if has_command dpkg ; then
-    if ! dpkg --status zlib1g-dev ; then
-        test_fail "System dependencies were not installed properly"
+echo "Verifying system dependencies were installed..."
+for dep in "${system_deps[@]}"; do
+    if has_command dpkg ; then
+        if ! dpkg --status "$dep" > /dev/null ; then
+            test_fail "System dependency $dep was not installed properly"
+        fi
+    elif has_command rpm ; then
+        if ! rpm -q "$dep" > /dev/null ; then
+            test_fail "System dependency $dep was not installed properly"
+        fi
     fi
-elif has_command rpm ; then
-    if ! rpm -q libcurl-devel ; then
-        test_fail "System dependencies were not installed properly"
-    fi
-fi
+    echo "System dependency $dep was installed successfully"
+done
 
 swiftly install latest
 

--- a/install/tests/default-install.sh
+++ b/install/tests/default-install.sh
@@ -22,7 +22,13 @@ cleanup () {
 }
 trap cleanup EXIT
 
-echo "1" | ./swiftly-install.sh
+if has_command apt-get ; then
+    apt-get remove -y libstdc++-11-dev
+elif has_command yum ; then
+    yum remove -y libcurl-devel
+fi
+
+printf "1\ny\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH.
 bash --login -c "swiftly --version"
@@ -35,6 +41,16 @@ fi
 
 if [[ ! -d "$HOME/.local/share/swiftly/toolchains" ]]; then
     test_fail "the toolchains directory was not created in SWIFTLY_HOME_DIR"
+fi
+
+if has_command dpkg ; then
+    if ! dpkg --status libstdc++-11-dev ; then
+        test_fail "System dependencies were not installed properly"
+    fi
+elif has_command rpm ; then
+    if ! rpm -q libcurl-devel ; then
+        test_fail "System dependencies were not installed properly"
+    fi
 fi
 
 swiftly install latest

--- a/install/tests/disable-prompt.sh
+++ b/install/tests/disable-prompt.sh
@@ -15,6 +15,12 @@ cleanup () {
 }
 trap cleanup EXIT
 
+if has_command apt-get ; then
+    apt-get remove -y zlib1g-dev
+elif has_command yum ; then
+    yum remove -y libcurl-devel
+fi
+
 ./swiftly-install.sh -y
 
 # .profile should be updated to update PATH.
@@ -39,6 +45,16 @@ fi
 CONFIG_CONTENTS="$(cat $HOME/.local/share/swiftly/config.json)"
 if [ "$CONFIG_CONTENTS" == "$DUMMY_CONTENT" ]; then
     fail_test "Config should have been overwritten after second install"
+fi
+
+if has_command dpkg ; then
+    if ! dpkg --status zlib1g-dev ; then
+        test_fail "System dependencies were not installed properly"
+    fi
+elif has_command rpm ; then
+    if ! rpm -q libcurl-devel ; then
+        test_fail "System dependencies were not installed properly"
+    fi
 fi
 
 test_pass

--- a/install/tests/disable-prompt.sh
+++ b/install/tests/disable-prompt.sh
@@ -21,7 +21,7 @@ elif has_command yum ; then
     yum remove -y libcurl-devel
 fi
 
-./swiftly-install.sh -y
+DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh -y
 
 # .profile should be updated to update PATH.
 bash --login -c "swiftly --version"
@@ -36,7 +36,7 @@ DUMMY_CONTENT="should be overwritten"
 echo "$DUMMY_CONTENT" > "$HOME/.local/share/swiftly/config.json"
 
 # Running it again should overwrite the previous installation without asking us for permission.
-./swiftly-install.sh --disable-confirmation
+DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh --disable-confirmation
 
 if ! has_command "swiftly" ; then
     fail_test "Can't find swiftly on the PATH"

--- a/install/tests/no-install-dependencies.sh
+++ b/install/tests/no-install-dependencies.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Tests passing --no-install-system-deps disables installing system dependencies.
+# Also verifies that interactive customization also does cancels them.
+# WARNING: this test makes changes to the local filesystem and is intended to be run in a containerized environment.
+
+set -o errexit
+source ./test-util.sh
+
+cleanup () {
+    set +o errexit
+
+    rm -r "$HOME/.local/share/swiftly"
+    rm "$HOME/.local/bin/swiftly"
+}
+trap cleanup EXIT
+
+verify_dependencies_not_installed () {
+    if has_command dpkg ; then
+        if dpkg --status libstdc++-11-dev ; then
+            test_fail "System dependencies were installed when they shouldn't have been"
+        fi
+    elif has_command rpm ; then
+        if rpm -q libcurl-devel ; then
+            test_fail "System dependencies were installed when they shouldn't have been"
+        fi
+    fi
+}
+
+if has_command apt-get ; then
+    apt-get remove -y libstdc++-11-dev
+elif has_command yum ; then
+    yum remove -y libcurl-devel
+fi
+
+echo "1" | ./swiftly-install.sh --no-install-system-deps
+
+verify_dependencies_not_installed
+
+# Use all defaults except "n" for system dependency installation.
+printf "2\n\n\n\nn\n1\ny\n" | ./swiftly-install.sh
+
+verify_dependencies_not_installed
+
+test_pass

--- a/install/tests/no-install-dependencies.sh
+++ b/install/tests/no-install-dependencies.sh
@@ -17,7 +17,7 @@ trap cleanup EXIT
 
 verify_dependencies_not_installed () {
     if has_command dpkg ; then
-        if dpkg --status libstdc++-11-dev ; then
+        if dpkg --status zlib1g-dev ; then
             test_fail "System dependencies were installed when they shouldn't have been"
         fi
     elif has_command rpm ; then
@@ -28,7 +28,7 @@ verify_dependencies_not_installed () {
 }
 
 if has_command apt-get ; then
-    apt-get remove -y libstdc++-11-dev
+    apt-get remove -y zlib1g-dev
 elif has_command yum ; then
     yum remove -y libcurl-devel
 fi

--- a/install/tests/overwrite.sh
+++ b/install/tests/overwrite.sh
@@ -17,7 +17,7 @@ cleanup () {
 }
 trap cleanup EXIT
 
-./swiftly-install.sh -y
+./swiftly-install.sh -y --no-install-system-deps
 
 . "$SWIFTLY_HOME_DIR/env.sh"
 
@@ -48,7 +48,7 @@ if [[ ! -d "$SWIFTLY_HOME_DIR/toolchains/5.7.3" ]]; then
 fi
 
 # Attempt the same installation, but overwrite this time.
-printf "1\ny\n" | ./swiftly-install.sh
+printf "1\ny\n" | ./swiftly-install.sh --no-install-system-deps
 
 if ! has_command "swiftly" ; then
     test_fail "Can't find swiftly on the PATH"

--- a/install/tests/update-bash-profile.sh
+++ b/install/tests/update-bash-profile.sh
@@ -23,7 +23,7 @@ touch "$HOME/.bash_profile"
 touch "$HOME/.bash_login"
 export SHELL="bash"
 
-echo "1" | ./swiftly-install.sh
+echo "1" | ./swiftly-install.sh --no-install-system-deps
 
 if [[ ! "$(cat $HOME/.bash_profile)" =~ "swiftly/env.sh" ]]; then
    test_fail "install did not update .bash_profile"
@@ -34,7 +34,7 @@ if [[ "$(cat $HOME/.bash_login)" != "" ]]; then
 fi
 
 rm "$HOME/.bash_profile"
-printf "1\ny\n" | ./swiftly-install.sh
+printf "1\ny\n" | ./swiftly-install.sh --no-install-system-deps
 
 if [[ -f "$HOME/.bash_profile" ]]; then
    test_fail "install created .bash_profile when it should not have"

--- a/install/tests/update-zprofile.sh
+++ b/install/tests/update-zprofile.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 touch "$HOME/.zprofile"
 export SHELL="zsh"
 
-echo "1" | ./swiftly-install.sh
+echo "1" | ./swiftly-install.sh --no-install-system-deps
 
 if [[ ! "$(cat $HOME/.zprofile)" =~ "swiftly/env.sh" ]]; then
    test_fail "install did not update .zprofile"


### PR DESCRIPTION
Closes #32

This works by scraping the dependency list from the dockerfiles at https://github.com/apple/swift-docker. Long-term, we'll want to get the list of dependencies from a swift.org API.

The design originally called for us to not do this due to different Swift releases having different system dependencies, but upon further reflection, this seems like a big enough ergonomic win that we might as well do it.