### PR TITLE
Always disable confirmation when installing system dependencies

### DIFF
--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -152,10 +152,7 @@ install_system_deps () {
         unset 'package_list[-1]'
     fi
 
-    install_args=(--quiet)
-    if [[ "$DISABLE_CONFIRMATION" == "true" ]]; then
-        install_args+=(-y)
-    fi
+    install_args=(--quiet -y)
 
     # Disable errexit since failing to install system dependencies is not swiftly installation-fatal.
     set +o errexit
@@ -250,6 +247,7 @@ case "$ID" in
     "ubuntu")
         docker_platform_name="ubuntu"
         package_manager="apt-get"
+        export DEBIAN_FRONTEND=noninteractive
         case "$UBUNTU_CODENAME" in
             "jammy")
                 PLATFORM_NAME="ubuntu2204"

--- a/install/tests/custom-install.sh
+++ b/install/tests/custom-install.sh
@@ -24,6 +24,10 @@ cleanup () {
 }
 trap cleanup EXIT
 
+# Custom home dir
+# Custom bin dir
+# Modify login config (yes)
+# Install system dependencies (no)
 printf "2\n$CUSTOM_HOME_DIR\n$CUSTOM_BIN_DIR\ny\nn\n1\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH and SWIFTLY_HOME_DIR/SWIFTLY_BIN_DIR.

--- a/install/tests/default-install.sh
+++ b/install/tests/default-install.sh
@@ -118,7 +118,7 @@ elif has_command yum ; then
     yum remove -y "${system_deps[@]}"
 fi
 
-printf "1\ny\n" | DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh
+printf "1\n" | ./swiftly-install.sh
 
 # .profile should be updated to update PATH.
 bash --login -c "swiftly --version"

--- a/install/tests/disable-prompt.sh
+++ b/install/tests/disable-prompt.sh
@@ -21,7 +21,7 @@ elif has_command yum ; then
     yum remove -y libcurl-devel
 fi
 
-DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh -y
+./swiftly-install.sh -y
 
 # .profile should be updated to update PATH.
 bash --login -c "swiftly --version"
@@ -36,7 +36,7 @@ DUMMY_CONTENT="should be overwritten"
 echo "$DUMMY_CONTENT" > "$HOME/.local/share/swiftly/config.json"
 
 # Running it again should overwrite the previous installation without asking us for permission.
-DEBIAN_FRONTEND="noninteractive" ./swiftly-install.sh --disable-confirmation
+./swiftly-install.sh --disable-confirmation
 
 if ! has_command "swiftly" ; then
     fail_test "Can't find swiftly on the PATH"


### PR DESCRIPTION
This fixes a bug similar to the one identified in #51, wherein `curl ... | bash` installation would fail due to stdin being EOF. In this case, `apt-get` was hanging because it needed some input to install the `tzdata` package. To address this, I've updated the system deps installation phase to just always proceed without confirmation. If a user wants to disable the installation of system deps, they already had to confirm as much during the options prompting phase.