### PR TITLE
Accept SNAPSHOT in toolchain selector parsing

### DIFF
--- a/Sources/SwiftlyCore/ToolchainVerison.swift
+++ b/Sources/SwiftlyCore/ToolchainVerison.swift
@@ -285,6 +285,8 @@ public enum ToolchainSelector {
     }
 }
 
+extension ToolchainSelector: Equatable {}
+
 /// Protocol used to facilitate parsing `ToolchainSelector`s from strings.
 protocol ToolchainSelectorParser {
     func parse(_ string: String) throws -> ToolchainSelector?
@@ -328,9 +330,11 @@ struct StableReleaseParser: ToolchainSelectorParser {
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - a.b-DEVELOPMENT-SNAPSHOT
+///    - a.b-SNAPSHOT-YYYY-mm-dd
+///    - a.b-SNAPSHOT
 struct ReleaseSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring, Substring, Substring?)> =
-        try! Regex("^([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
+        try! Regex("^([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
 
     func parse(_ input: String) throws -> ToolchainSelector? {
         guard let match = try Self.regex.wholeMatch(in: input) else {
@@ -351,12 +355,14 @@ struct ReleaseSnapshotParser: ToolchainSelectorParser {
 /// Parser for selectors like the following:
 ///    - main-snapshot-YYYY-mm-dd
 ///    - main-snapshot
+///    - main-SNAPSHOT-YYYY-mm-dd
+///    - main-SNAPSHOT
 ///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
 ///    - swift-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd
 ///    - swift-DEVELOPMENT-SNAPSHOT
 struct MainSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring?)> =
-        try! Regex("^(?:main-snapshot|swift-DEVELOPMENT-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
+        try! Regex("^(?:main-snapshot|swift-DEVELOPMENT-SNAPSHOT|main-SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
 
     func parse(_ input: String) throws -> ToolchainSelector? {
         guard let match = try Self.regex.wholeMatch(in: input) else {

--- a/Tests/SwiftlyTests/ToolchainSelectorTests.swift
+++ b/Tests/SwiftlyTests/ToolchainSelectorTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftlyCore
+import XCTest
+
+final class ToolchainSelectorTests: SwiftlyTests {
+    func runTest(_ expected: ToolchainSelector, _ parses: [String]) throws {
+        for string in parses {
+            XCTAssertEqual(try ToolchainSelector(parsing: string), expected)
+        }
+    }
+
+    func testParseLatest() throws {
+        try self.runTest(.latest, ["latest"])
+    }
+
+    func testParseRelease() throws {
+        try self.runTest(.stable(major: 5, minor: 7, patch: 3), ["5.7.3"])
+        try self.runTest(.stable(major: 5, minor: 7, patch: nil), ["5.7"])
+        try self.runTest(.stable(major: 5, minor: nil, patch: nil), ["5"])
+    }
+
+    func testParseMainSnapshot() throws {
+        let parses = [
+            "main-snapshot",
+            "main-SNAPSHOT",
+            "swift-DEVELOPMENT-SNAPSHOT",
+        ]
+        try runTest(.snapshot(branch: .main, date: nil), parses)
+    }
+
+    func testParseMainSnapshotWithDate() throws {
+        let parses = [
+            "main-snapshot-2023-06-05",
+            "main-SNAPSHOT-2023-06-05",
+            "swift-DEVELOPMENT-SNAPSHOT-2023-06-05",
+            "swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+        ]
+        try runTest(.snapshot(branch: .main, date: "2023-06-05"), parses)
+    }
+
+    func testParseReleaseSnapshot() throws {
+        let parses = [
+            "5.7-snapshot",
+            "5.7-SNAPSHOT",
+            "5.7-DEVELOPMENT-SNAPSHOT",
+        ]
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: nil), parses)
+    }
+
+    func testParseReleaseSnapshotWithDate() throws {
+        let parses = [
+            "5.7-snapshot-2023-06-05",
+            "5.7-SNAPSHOT-2023-06-05",
+            "5.7-DEVELOPMENT-SNAPSHOT-2023-06-05",
+            "5.7-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+        ]
+        try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: "2023-06-05"), parses)
+    }
+}


### PR DESCRIPTION
This PR changes `ToolchainSelector` parsing to now accept inputs such as `5.7-SNAPSHOT` or `main-SNAPSHOT`. I opted not to add `swift-SNAPSHOT` as an alternative for `main-snapshot` since it would be another set of words we'd be accepting, whereas `main-SNAPSHOT` is only a difference of capitalization from the existing `main-snapshot`.