### PR TITLE
[Feature] Add initial macOS support for compiling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,8 @@ import PackageDescription
 
 let package = Package(
     name: "swiftly",
+    // Current supported Darwin family: macOS
+    platforms: [.macOS(.v13)],
     products: [
         .executable(
             name: "swiftly",
@@ -23,6 +25,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .target(name: "SwiftlyCore"),
                 .target(name: "LinuxPlatform", condition: .when(platforms: [.linux])),
+                .target(name: "DarwinPlatform", condition: .when(platforms: [.macOS])),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
             ]
         ),
@@ -34,13 +37,29 @@ let package = Package(
             ]
         ),
         .target(
-            name: "LinuxPlatform",
+            name: "DarwinPlatform",
             dependencies: [
                 "SwiftlyCore",
-                "CLibArchive",
+                "Archive",
             ],
             linkerSettings: [
                 .linkedLibrary("z"),
+            ]
+        ),
+        .target(
+            name: "LinuxPlatform",
+            dependencies: [
+                "SwiftlyCore",
+                "Archive",
+            ],
+            linkerSettings: [
+                .linkedLibrary("z"),
+            ]
+        ),
+        .target(
+            name: "Archive",
+            dependencies: [
+                "CLibArchive",
             ]
         ),
         .systemLibrary(
@@ -48,6 +67,9 @@ let package = Package(
             pkgConfig: "libarchive",
             providers: [
                 .apt(["libarchive-dev"]),
+                // For pkg-config to find libarchive you may need to set:
+                // `export PKG_CONFIG_PATH="/opt/homebrew/opt/libarchive/lib/pkgconfig"`
+                .brew(["libarchive"]),
             ]
         ),
         .testTarget(

--- a/Sources/Archive/Extract.swift
+++ b/Sources/Archive/Extract.swift
@@ -1,19 +1,19 @@
-import CLibArchive
+@_implementationOnly import CLibArchive
 import Foundation
 
 // The code in this file consists mainly of a Swift port of the "Complete Extractor" example included in the libarchive
 // documentation: https://github.com/libarchive/libarchive/wiki/Examples#a-complete-extractor
 
-struct ExtractError: Error {
-    let message: String?
+public struct ExtractError: Error {
+    public let message: String?
 
-    init(archive: OpaquePointer?) {
+    internal init(archive: OpaquePointer?) {
         self.message = archive_error_string(archive).map { err in
             String(cString: err)
         }
     }
 
-    init(message: String) {
+    public init(message: String) {
         self.message = message
     }
 }
@@ -44,7 +44,7 @@ func copyData(readArchive: OpaquePointer?, writeArchive: OpaquePointer?) throws 
 /// the provided closure which will return the path the file will be written to.
 ///
 /// This uses libarchive under the hood, so a wide variety of archive formats are supported (e.g. .tar.gz).
-internal func extractArchive(atPath archivePath: URL, transform: (String) -> URL) throws {
+public func extractArchive(atPath archivePath: URL, transform: (String) -> URL) throws {
     var flags = Int32(0)
     flags = ARCHIVE_EXTRACT_TIME
     flags |= ARCHIVE_EXTRACT_PERM

--- a/Sources/DarwinPlatform/Darwin.swift
+++ b/Sources/DarwinPlatform/Darwin.swift
@@ -2,10 +2,10 @@ import Foundation
 import SwiftlyCore
 @_implementationOnly import Archive
 
-/// `Platform` implementation for Linux systems.
-/// This implementation can be reused for any supported Linux platform.
+/// `Platform` implementation for Darwin systems.
+/// This implementation can be reused for any supported Darwin platform.
 /// TODO: replace dummy implementations
-public struct Linux: Platform {
+public struct Darwin: Platform {
     public init() {}
 
     public var appDataDirectory: URL {
@@ -19,7 +19,7 @@ public struct Linux: Platform {
     }
 
     public var toolchainFileExtension: String {
-        "tar.gz"
+        "pkg"
     }
 
     public func isSystemDependencyPresent(_: SystemDependency) -> Bool {
@@ -140,5 +140,5 @@ public struct Linux: Platform {
         FileManager.default.temporaryDirectory.appendingPathComponent("swiftly-\(UUID())")
     }
 
-    public static let currentPlatform: any Platform = Linux()
+    public static let currentPlatform: any Platform = Darwin()
 }

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -2,6 +2,8 @@ import ArgumentParser
 import Foundation
 #if os(Linux)
 import LinuxPlatform
+#elseif canImport(Darwin)
+import DarwinPlatform
 #endif
 import SwiftlyCore
 
@@ -35,6 +37,8 @@ public struct Swiftly: SwiftlyCommand {
 
 #if os(Linux)
     internal static let currentPlatform = Linux.currentPlatform
+#elseif canImport(Darwin)
+    internal static let currentPlatform = Darwin.currentPlatform
 #endif
 }
 


### PR DESCRIPTION
## Related issue:

#21

## Description

This PR add initial Darwin platform support for compiling.

Many feature is missing and it does not mean we support macOS on this PR.

## TODO & Future Plan

- [ ] Add `name` getter in `Platform` protocol as described in Design.md
- [ ] Extract the same logic in `Linux` and `Darwin` to SwiftlyCore via `extension Platform`
- [ ] Update Darwin implementation to better respect the OS - toolchain install path / file extension / Xcode integration