### PR TITLE
Support "swift-" prefix when parsing release snapshot selectors

### DIFF
--- a/Sources/SwiftlyCore/ToolchainVerison.swift
+++ b/Sources/SwiftlyCore/ToolchainVerison.swift
@@ -324,7 +324,7 @@ struct StableReleaseParser: ToolchainSelectorParser {
     }
 }
 
-/// Parser for selectors like the following:
+/// Parser for selectors like the following (with optional "swift-" prefix):
 ///    - a.b-snapshot-YYYY-mm-dd
 ///    - a.b-snapshot
 ///    - a.b-DEVELOPMENT-SNAPSHOT-YYYY-mm-dd-a
@@ -334,7 +334,7 @@ struct StableReleaseParser: ToolchainSelectorParser {
 ///    - a.b-SNAPSHOT
 struct ReleaseSnapshotParser: ToolchainSelectorParser {
     static let regex: Regex<(Substring, Substring, Substring, Substring?)> =
-        try! Regex("^([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
+        try! Regex("^(?:swift-)?([0-9]+)\\.([0-9]+)-(?:snapshot|DEVELOPMENT-SNAPSHOT|SNAPSHOT)(?:-([0-9]{4}-[0-9]{2}-[0-9]{2}))?(?:-a)?$")
 
     func parse(_ input: String) throws -> ToolchainSelector? {
         guard let match = try Self.regex.wholeMatch(in: input) else {

--- a/Tests/SwiftlyTests/ToolchainSelectorTests.swift
+++ b/Tests/SwiftlyTests/ToolchainSelectorTests.swift
@@ -43,6 +43,9 @@ final class ToolchainSelectorTests: SwiftlyTests {
             "5.7-snapshot",
             "5.7-SNAPSHOT",
             "5.7-DEVELOPMENT-SNAPSHOT",
+            "swift-5.7-snapshot",
+            "swift-5.7-SNAPSHOT",
+            "swift-5.7-DEVELOPMENT-SNAPSHOT",
         ]
         try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: nil), parses)
     }
@@ -53,6 +56,10 @@ final class ToolchainSelectorTests: SwiftlyTests {
             "5.7-SNAPSHOT-2023-06-05",
             "5.7-DEVELOPMENT-SNAPSHOT-2023-06-05",
             "5.7-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
+            "swift-5.7-snapshot-2023-06-05",
+            "swift-5.7-SNAPSHOT-2023-06-05",
+            "swift-5.7-DEVELOPMENT-SNAPSHOT-2023-06-05",
+            "swift-5.7-DEVELOPMENT-SNAPSHOT-2023-06-05-a",
         ]
         try runTest(.snapshot(branch: .release(major: 5, minor: 7), date: "2023-06-05"), parses)
     }


### PR DESCRIPTION
Closes #69 