### PR TITLE
Implement `self-update` command

### DIFF
--- a/Sources/LinuxPlatform/Linux.swift
+++ b/Sources/LinuxPlatform/Linux.swift
@@ -131,7 +131,9 @@ public struct Linux: Platform {
         []
     }
 
-    public func selfUpdate() async throws {}
+    public func getExecutableName(forArch: String) -> String {
+        return "swiftly-\(forArch)-unknown-linux-gnu"
+    }
 
     public func currentToolchain() throws -> ToolchainVersion? { nil }
 

--- a/Sources/Swiftly/Config.swift
+++ b/Sources/Swiftly/Config.swift
@@ -23,6 +23,10 @@ public struct Config: Codable, Equatable {
 
         /// The CPU architecture of the platform. If omitted, assumed to be x86_64.
         public let architecture: String?
+
+        public func getArchitecture() -> String {
+            return self.architecture ?? "x86_64"
+        }
     }
 
     public var inUse: ToolchainVersion?

--- a/Sources/Swiftly/Install.swift
+++ b/Sources/Swiftly/Install.swift
@@ -126,6 +126,10 @@ struct Install: SwiftlyCommand {
             url += "\(snapshotString)-\(release.date)-a-\(platformFullString).\(Swiftly.currentPlatform.toolchainFileExtension)"
         }
 
+        guard let url = URL(string: url) else {
+            throw Error(message: "Invalid toolchain URL: \(url)")
+        }
+
         let animation = PercentProgressAnimation(
             stream: stdoutStream,
             header: "Downloading \(version)"
@@ -134,10 +138,9 @@ struct Install: SwiftlyCommand {
         var lastUpdate = Date()
 
         do {
-            try await httpClient.downloadToolchain(
-                version,
+            try await httpClient.downloadFile(
                 url: url,
-                to: tmpFile.path,
+                to: tmpFile,
                 reportProgress: { progress in
                     let now = Date()
 

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -1,12 +1,76 @@
 import ArgumentParser
+import Foundation
+import TSCBasic
+import TSCUtility
+
+import SwiftlyCore
+
+fileprivate struct SwiftlyRelease: Decodable {
+    fileprivate let name: String
+}
 
 internal struct SelfUpdate: SwiftlyCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Update the version of swiftly itself."
     )
 
+    private var httpClient = SwiftlyHTTPClient()
+
+    private enum CodingKeys: CodingKey {}
+
     internal mutating func run() async throws {
-        print("updating swiftly")
-        try await Swiftly.currentPlatform.selfUpdate()
+        SwiftlyCore.print("Checking for updates...")
+
+        let release: SwiftlyRelease = try await self.httpClient.getFromGitHub(
+            url: "https://api.github.com/repos/swift-server/swiftly/releases/latest"
+        )
+
+        // guard release.name > Swiftly.configuration.version else {
+        //     SwiftlyCore.print("Already up to date.")
+        //     return
+        // }
+
+        SwiftlyCore.print("A new version is available: \(release.name)")
+
+        let config = try Config.load()
+        let executableName = Swiftly.currentPlatform.getExecutableName(forArch: config.platform.getArchitecture())
+        let downloadURL = URL(string: "https://github.com/swift-server/swiftly/releases/latest/download/\(executableName)")!
+
+        let tmpFile = Swiftly.currentPlatform.getTempFilePath()
+        FileManager.default.createFile(atPath: tmpFile.path, contents: nil)
+        defer {
+            try? FileManager.default.removeItem(at: tmpFile)
+        }
+
+        let animation = PercentProgressAnimation(
+            stream: stdoutStream,
+            header: "Downloading swiftly \(release.name)"
+        )
+        do {
+            try await httpClient.downloadFile(
+                url: downloadURL,
+                to: tmpFile,
+                reportProgress: { progress in
+                    let downloadedMiB = Double(progress.receivedBytes) / (1024.0 * 1024.0)
+                    let totalMiB = Double(progress.totalBytes!) / (1024.0 * 1024.0)
+
+                    animation.update(
+                        step: progress.receivedBytes,
+                        total: progress.totalBytes!,
+                        text: "Downloaded \(String(format: "%.1f", downloadedMiB)) MiB of \(String(format: "%.1f", totalMiB)) MiB"
+                    )
+                }
+            )
+        } catch {
+            animation.complete(success: false)
+            throw error
+        }
+        animation.complete(success: true)
+
+        let swiftlyExecutable = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent("swiftly", isDirectory: false)
+        try FileManager.default.removeItem(at: swiftlyExecutable)
+        try FileManager.default.moveItem(at: tmpFile, to: swiftlyExecutable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: swiftlyExecutable.path)
+        SwiftlyCore.print("Successfully updated swiftly to \(release.name) (was \(Swiftly.configuration.version))")
     }
 }

--- a/Sources/Swiftly/SelfUpdate.swift
+++ b/Sources/Swiftly/SelfUpdate.swift
@@ -10,7 +10,7 @@ internal struct SelfUpdate: SwiftlyCommand {
         abstract: "Update the version of swiftly itself."
     )
 
-    private var httpClient = SwiftlyHTTPClient()
+    internal var httpClient = SwiftlyHTTPClient()
 
     private enum CodingKeys: CodingKey {}
 

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -19,6 +19,7 @@ public struct Swiftly: SwiftlyCommand {
             Uninstall.self,
             List.self,
             Update.self,
+            SelfUpdate.self,
         ]
     )
 

--- a/Sources/Swiftly/Swiftly.swift
+++ b/Sources/Swiftly/Swiftly.swift
@@ -8,10 +8,12 @@ import SwiftlyCore
 @main
 @available(macOS 10.15, *)
 public struct Swiftly: SwiftlyCommand {
+    public static let version = SwiftlyVersion(major: 0, minor: 1, patch: 0)
+
     public static var configuration = CommandConfiguration(
         abstract: "A utility for installing and managing Swift toolchains.",
 
-        version: "0.1.0",
+        version: String(describing: Self.version),
 
         subcommands: [
             Install.self,

--- a/Sources/Swiftly/SwiftlyVersion.swift
+++ b/Sources/Swiftly/SwiftlyVersion.swift
@@ -2,10 +2,11 @@ import Foundation
 import _StringProcessing
 import SwiftlyCore
 
+/// Struct modeling a version of swiftly itself.
 public struct SwiftlyVersion: Equatable, Comparable, CustomStringConvertible {
     /// Regex matching versions like "a.b.c", "a.b.c-alpha", and "a.b.c-alpha2".
     static let regex: Regex<(Substring, Substring, Substring, Substring, Substring?)> =
-        try! Regex("^(\\d+)\\.(\\d+)\\.(\\d+)(:?-([a-zA-Z0-9]+))?$")
+        try! Regex("^(\\d+)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9]+))?$")
 
     public let major: Int
     public let minor: Int

--- a/Sources/Swiftly/SwiftlyVersion.swift
+++ b/Sources/Swiftly/SwiftlyVersion.swift
@@ -1,0 +1,61 @@
+import Foundation
+import _StringProcessing
+import SwiftlyCore
+
+public struct SwiftlyVersion: Equatable, Comparable, CustomStringConvertible {
+    /// Regex matching versions like "a.b.c", "a.b.c-alpha", and "a.b.c-alpha2".
+    static let regex: Regex<(Substring, Substring, Substring, Substring, Substring?)> =
+        try! Regex("^(\\d+)\\.(\\d+)\\.(\\d+)(:?-([a-zA-Z0-9]+))?$")
+
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+    public let suffix: String?
+
+    public init(major: Int, minor: Int, patch: Int, suffix: String? = nil) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.suffix = suffix
+    }
+
+    public init(parsing tag: String) throws {
+        guard let match = try Self.regex.wholeMatch(in: tag) else {
+            throw Error(message: "unable to parse release tag: \"\(tag)\"")
+        }
+
+        self.major = Int(match.output.1)!
+        self.minor = Int(match.output.2)!
+        self.patch = Int(match.output.3)!
+        self.suffix = match.output.4.flatMap(String.init)
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        } else if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        } else if lhs.patch != rhs.patch {
+            return lhs.patch < rhs.patch
+        } else {
+            switch (lhs.suffix, rhs.suffix) {
+            case (.none, .some):
+                return false
+            case (.some, .none):
+                return true
+            case let (.some(lhsSuffix), .some(rhsSuffix)):
+                return lhsSuffix < rhsSuffix
+            case (.none, .none):
+                return false
+            }
+        }
+    }
+
+    public var description: String {
+        var base = "\(self.major).\(self.minor).\(self.patch)"
+        if let suffix = self.suffix {
+            base += "-\(suffix)"
+        }
+        return base
+    }
+}

--- a/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
+++ b/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
@@ -5,7 +5,7 @@ import Foundation
 extension SwiftlyHTTPClient {
     /// Get a JSON response from the GitHub REST API.
     /// This will use the authorization token set, if any.
-    private func getFromGitHub<T: Decodable>(url: String) async throws -> T {
+    public func getFromGitHub<T: Decodable>(url: String) async throws -> T {
         var headers: [String: String] = [:]
         if let token = self.githubToken ?? ProcessInfo.processInfo.environment["SWIFTLY_GITHUB_TOKEN"] {
             headers["Authorization"] = "Bearer \(token)"

--- a/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
+++ b/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
@@ -2,6 +2,10 @@ import _StringProcessing
 import AsyncHTTPClient
 import Foundation
 
+public struct SwiftlyGitHubRelease: Codable {
+    public let tag: String
+}
+
 extension SwiftlyHTTPClient {
     /// Get a JSON response from the GitHub REST API.
     /// This will use the authorization token set, if any.

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -16,80 +16,64 @@ public protocol ToolchainDownloader {
     ) async throws
 }
 
-/// The default implementation of a toolchain downloader.
-/// Downloads toolchains from swift.org.
-private struct HTTPToolchainDownloader: ToolchainDownloader {
-    func downloadToolchain(
-        _: ToolchainVersion,
-        url: String,
-        to destination: String,
-        reportProgress: @escaping (SwiftlyHTTPClient.DownloadProgress) -> Void
-    ) async throws {
-        let fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: destination))
-        defer {
-            try? fileHandle.close()
-        }
+public protocol HTTPRequestExecutor {
+    func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse
+}
 
-        let request = SwiftlyHTTPClient.client.makeRequest(url: url)
-        let response = try await SwiftlyHTTPClient.client.inner.execute(request, timeout: .seconds(30))
+private struct MockHTTPClient: HTTPRequestExecutor {
+    private let handler: (HTTPClientRequest) async throws -> HTTPClientResponse
 
-        guard case response.status = HTTPResponseStatus.ok else {
-            throw Error(message: "Received \(response.status) when trying to download \(url)")
-        }
-
-        // Unknown download.swift.org paths redirect to a 404 page which then returns a 200 status.
-        // As a heuristic for if we've hit the 404 page, we check to see if the content is HTML.
-        guard !response.headers["Content-Type"].contains(where: { $0.contains("text/html") }) else {
-            throw SwiftlyHTTPClient.DownloadNotFoundError(url: url)
-        }
-
-        // if defined, the content-length headers announces the size of the body
-        let expectedBytes = response.headers.first(name: "content-length").flatMap(Int.init)
-
-        var receivedBytes = 0
-        for try await buffer in response.body {
-            receivedBytes += buffer.readableBytes
-
-            try buffer.withUnsafeReadableBytes { bufferPtr in
-                try fileHandle.write(contentsOf: bufferPtr)
-            }
-            reportProgress(SwiftlyHTTPClient.DownloadProgress(
-                receivedBytes: receivedBytes,
-                totalBytes: expectedBytes
-            )
-            )
-        }
-
-        try fileHandle.synchronize()
+    public init(handler: @escaping (HTTPClientRequest) async throws -> HTTPClientResponse) {
+        self.handler = handler
     }
+
+    public func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse {
+        return try await self.handler(request)
+    }
+}
+
+private struct AsyncHTTPClient: HTTPRequestExecutor {
+    fileprivate static let client = HTTPClientWrapper()
+
+    public func execute(_ request: HTTPClientRequest, timeout: TimeAmount) async throws -> HTTPClientResponse {
+        return try await Self.client.inner.execute(request, timeout: timeout)
+    }
+}
+
+fileprivate func makeRequest(url: String) -> HTTPClientRequest {
+    var request = HTTPClientRequest(url: url)
+    request.headers.add(name: "User-Agent", value: "swiftly")
+    return request
 }
 
 /// HTTPClient wrapper used for interfacing with various REST APIs and downloading things.
 public struct SwiftlyHTTPClient {
-    fileprivate static let client = HTTPClientWrapper()
-
     private struct Response {
         let status: HTTPResponseStatus
         let buffer: ByteBuffer
     }
 
-    private let downloader: ToolchainDownloader
+    private let inner: HTTPRequestExecutor
 
     /// The GitHub authentication token to use for any requests made to the GitHub API.
     public var githubToken: String?
 
-    public init(toolchainDownloader: ToolchainDownloader? = nil) {
-        self.downloader = toolchainDownloader ?? HTTPToolchainDownloader()
+    public static func mocked(_ handler: @escaping (HTTPClientRequest) async throws -> HTTPClientResponse) -> Self {
+        return Self(inner: MockHTTPClient(handler: handler))
+    }
+
+    public init(inner: HTTPRequestExecutor? = nil) {
+        self.inner = inner ?? AsyncHTTPClient()
     }
 
     private func get(url: String, headers: [String: String]) async throws -> Response {
-        var request = Self.client.makeRequest(url: url)
+        var request = makeRequest(url: url)
 
         for (k, v) in headers {
             request.headers.add(name: k, value: v)
         }
 
-        let response = try await Self.client.inner.execute(request, timeout: .seconds(30))
+        let response = try await self.inner.execute(request, timeout: .seconds(30))
 
         // if defined, the content-length headers announces the size of the body
         let expectedBytes = response.headers.first(name: "content-length").flatMap(Int.init) ?? 1024 * 1024
@@ -185,7 +169,7 @@ public struct SwiftlyHTTPClient {
             try? fileHandle.close()
         }
 
-        let request = self.makeRequest(url: url.absoluteString)
+        let request = makeRequest(url: url.absoluteString)
         let response = try await self.inner.execute(request, timeout: .seconds(30))
 
         guard case response.status = HTTPResponseStatus.ok else {
@@ -194,8 +178,13 @@ public struct SwiftlyHTTPClient {
 
         // Unknown download.swift.org paths redirect to a 404 page which then returns a 200 status.
         // As a heuristic for if we've hit the 404 page, we check to see if the content is HTML.
-        guard !response.headers["Content-Type"].contains(where: { $0.contains("text/html") }) else {
-            // TODO: handle this better
+        if url.host == "download.swift.org" {
+            guard !response.headers["Content-Type"].contains(where: { $0.contains("text/html") }) else {
+                throw SwiftlyHTTPClient.DownloadNotFoundError(url: url.path)
+            }
+        }
+
+        guard response.status != .notFound else {
             throw SwiftlyHTTPClient.DownloadNotFoundError(url: url.path)
         }
 
@@ -221,20 +210,6 @@ public struct SwiftlyHTTPClient {
         }
 
         try fileHandle.synchronize()
-    }
-
-    public func downloadToolchain(
-        _ toolchain: ToolchainVersion,
-        url: String,
-        to destination: String,
-        reportProgress: @escaping (DownloadProgress) -> Void
-    ) async throws {
-        try await self.downloader.downloadToolchain(
-            toolchain,
-            url: url,
-            to: destination,
-            reportProgress: reportProgress
-        )
     }
 }
 

--- a/Sources/SwiftlyCore/Platform.swift
+++ b/Sources/SwiftlyCore/Platform.swift
@@ -33,9 +33,8 @@ public protocol Platform {
     /// This will likely have a default implementation.
     func listAvailableSnapshots(version: String?) async -> [Snapshot]
 
-    /// Update swiftly itself, if a new version has been released.
-    /// This will likely have a default implementation.
-    func selfUpdate() async throws
+    /// Get the name of the release binary for this platform with the given CPU arch.
+    func getExecutableName(forArch: String) -> String
 
     /// Get a path pointing to a unique, temporary file.
     /// This does not need to actually create the file.

--- a/Tests/SwiftlyTests/SelfUpdateTests.swift
+++ b/Tests/SwiftlyTests/SelfUpdateTests.swift
@@ -1,0 +1,69 @@
+import AsyncHTTPClient
+import Foundation
+@testable import Swiftly
+@testable import SwiftlyCore
+import XCTest
+import NIO
+
+final class SelfUpdateTests: SwiftlyTests {
+    private static var newMajorVersion: String {
+        "\(Swiftly.version.major + 1).0.0"
+    }
+
+    private static var newMinorVersion: String {
+        "\(Swiftly.version.major).\(Swiftly.version.minor + 1).0)"
+    }
+
+    private static var newPatchVersion: String {
+        "\(Swiftly.version.major).\(Swiftly.version.minor).\(Swiftly.version.patch + 1))"
+    }
+
+    private static func makeMockHTTPClient(latestVersion: String) -> SwiftlyHTTPClient {
+        return .mocked { request in
+            guard let url = URL(string: request.url) else {
+                throw SwiftlyTestError(message: "invalid url \(request.url)")
+            }
+
+            switch url.host {
+            case "api.github.com":
+                let nextRelease = try SwiftlyGitHubRelease(tag: latestVersion)
+                var buffer = ByteBuffer()
+                try buffer.writeJSONEncodable(nextRelease)
+                return HTTPClientResponse(body: .bytes(buffer))
+            case "download.swift.org":
+                fatalError("blah")
+            default:
+                throw SwiftlyTestError(message: "unknown url host: \(url.host)")
+            }
+
+        }
+    }
+
+    /// Verify updating the most up-to-date toolchain has no effect.
+    func testUpdateLatest() async throws {
+        try await self.withTestHome {
+            var update = try self.parseCommand(Update.self, ["self-update"])
+
+            update.httpClient = .mocked { request in
+                guard let url = URL(string: request.url) else {
+                    throw SwiftlyTestError(message: "invalid url \(request.url)")
+                }
+
+                switch url.host {
+                case "api.github.com":
+                    let nextVersion = "TODO"
+                    let nextRelease = SwiftlyGitHubRelease(name: nextVersion)
+                    var buffer = ByteBuffer()
+                    try buffer.writeJSONEncodable(nextRelease)
+                    return HTTPClientResponse(body: .bytes(buffer))
+                case "download.swift.org":
+                    return 12
+                default:
+                    throw SwiftlyTestError(message: "unknown url host: \(url.host)")
+                }
+            }
+            try await update.run()
+
+        }
+    }
+}

--- a/Tests/SwiftlyTests/UpdateTests.swift
+++ b/Tests/SwiftlyTests/UpdateTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import XCTest
 
 final class UpdateTests: SwiftlyTests {
-    private let mockHttpClient = SwiftlyHTTPClient(toolchainDownloader: MockToolchainDownloader())
+    private let mockHttpClient = SwiftlyHTTPClient(inner: MockToolchainDownloader())
 
     /// Verify updating the most up-to-date toolchain has no effect.
     func testUpdateLatest() async throws {


### PR DESCRIPTION
Implements a `self-update` command, which can be used to update swiftly in-place.

This also expands the toolchain downloading mocking framework introduced in #67 to be able to be used for any arbitrary HTTP request. This allows us to use mocking to simulate there being a swiftly update to make, even though there are none currently.