### PR TITLE
Support updating exsting swiftly installation from swiftly-install.sh

### DIFF
--- a/install/run-tests.sh
+++ b/install/run-tests.sh
@@ -17,19 +17,18 @@ fi
 
 tests_failed=0
 tests_passed=0
+failed_tests=()
 
 for t in tests/*.sh; do
+    test_name=$(basename "$t")
     line_print
-    echo "Running test $t"
+    echo "Running test $test_name"
     echo ""
     if bash "$t"; then
-        echo ""
-        echo "$t PASSED"
         ((tests_passed++))
     else
-        echo ""
-        echo "$t FAILED"
         ((tests_failed++))
+        failed_tests+=("$test_name")
     fi
 done
 
@@ -38,6 +37,10 @@ line_print
 if [[ "$tests_failed" -gt 0 ]]; then
     echo ""
     echo "$tests_failed test(s) FAILED, $tests_passed test(s) PASSED"
+    echo "Failed tests:"
+    for failed_test in "${failed_tests[@]}"; do
+        echo "- $failed_test"
+    done
     exit 1
 else
     echo "All tests PASSED"

--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -547,6 +547,7 @@ if [[ -d "$HOME_DIR" ]]; then
     detected_existing_installation="true"
     if [[ "$overwrite_existing_intallation" == "true" ]]; then
         echo "Overwriting existing swiftly installation at $(replace_home_path $HOME_DIR)"
+        find $BIN_DIR -lname "$HOME_DIR/toolchains/**/bin/*" -delete
         rm -r $HOME_DIR
     else
         echo "Updating existing swiftly installation at $(replace_home_path $HOME_DIR)"

--- a/install/test-util.sh
+++ b/install/test-util.sh
@@ -4,6 +4,12 @@
 
 export SWIFTLY_READ_FROM_STDIN=1
 
+test_log () {
+    echo "==========================="
+    echo "$1"
+    echo "==========================="
+}
+
 has_command () {
     command -v "$1" > /dev/null
 }

--- a/install/test-util.sh
+++ b/install/test-util.sh
@@ -14,6 +14,10 @@ has_command () {
     command -v "$1" > /dev/null
 }
 
+test_name () {
+    basename "$0"
+}
+
 test_fail () {
     if [ ! -z "$1" ]; then
         printf "$1\n"
@@ -23,10 +27,14 @@ test_fail () {
         printf "actual: $2\n"
         printf "expected: $3\n"
     fi
+    echo ""
+    echo "$(test_name) FAILED"
     exit 1
 }
 
 test_pass () {
+    echo ""
+    echo "$(test_name) PASSED"
     exit 0
 }
 

--- a/install/tests/disable-prompt.sh
+++ b/install/tests/disable-prompt.sh
@@ -29,22 +29,7 @@ bash --login -c "swiftly --version"
 . "$HOME/.local/share/swiftly/env.sh"
 
 if ! has_command "swiftly" ; then
-    fail_test "Can't find swiftly on the PATH"
-fi
-
-DUMMY_CONTENT="should be overwritten"
-echo "$DUMMY_CONTENT" > "$HOME/.local/share/swiftly/config.json"
-
-# Running it again should overwrite the previous installation without asking us for permission.
-./swiftly-install.sh --disable-confirmation
-
-if ! has_command "swiftly" ; then
-    fail_test "Can't find swiftly on the PATH"
-fi
-
-CONFIG_CONTENTS="$(cat $HOME/.local/share/swiftly/config.json)"
-if [ "$CONFIG_CONTENTS" == "$DUMMY_CONTENT" ]; then
-    fail_test "Config should have been overwritten after second install"
+    test_fail "Can't find swiftly on the PATH"
 fi
 
 if has_command dpkg ; then

--- a/install/tests/overwrite.sh
+++ b/install/tests/overwrite.sh
@@ -7,16 +7,18 @@ set -o errexit
 source ./test-util.sh
 
 export SWIFTLY_HOME_DIR="./overwrite-test-home"
-export SWIFTLY_BIN_DIR="$SWIFTLY_HOME_DIR/bin"
+export SWIFTLY_BIN_DIR="./overwrite-bin-dir"
 
 cp "$HOME/.profile" "$HOME/.profile.bak"
 
 cleanup () {
     mv "$HOME/.profile.bak" "$HOME/.profile"
     rm -r "$SWIFTLY_HOME_DIR"
+    rm -r "$SWIFTLY_BIN_DIR"
 }
 trap cleanup EXIT
 
+test_log "Performing initial installation"
 ./swiftly-install.sh -y --no-install-system-deps
 
 . "$SWIFTLY_HOME_DIR/env.sh"
@@ -29,9 +31,16 @@ fi
 DUMMY_CONFIG_CONTENTS="hello world"
 PROFILE_CONTENTS="$(cat $HOME/.profile)"
 echo "$DUMMY_CONFIG_CONTENTS" > "$SWIFTLY_HOME_DIR/config.json"
-mkdir "$SWIFTLY_HOME_DIR/toolchains/5.7.3"
 
-# Attempt the same installation, but decline to overwrite.
+toolchain_dir="$SWIFTLY_HOME_DIR/toolchains/5.7.3"
+mkdir -p "$toolchain_dir/usr/bin"
+dummy_executable_name="foo"
+touch "$toolchain_dir/usr/bin/$dummy_executable_name"
+
+# Also set up a symlink as if the toolchain were in use.
+ln -s -t $SWIFTLY_BIN_DIR "$toolchain_dir/usr/bin/$dummy_executable_name"
+
+test_log "Attempting the same installation (no --overwrite flag specified)"
 ./swiftly-install.sh -y --no-install-system-deps
 
 if ! has_command "swiftly" ; then
@@ -43,11 +52,15 @@ if [[ "$NEW_CONFIG_CONTENTS" != "$DUMMY_CONFIG_CONTENTS" ]]; then
     test_fail "Expected config to remain unchanged" "$NEW_CONFIG_CONTENTS" "$DUMMY_CONFIG_CONTENTS"
 fi
 
+if ! [ -L "$SWIFTLY_BIN_DIR/$dummy_executable_name" ]; then
+    test_fail "Expected symlink to still exist, but it has been deleted"
+fi
+
 if [[ ! -d "$SWIFTLY_HOME_DIR/toolchains/5.7.3" ]]; then
     test_fail "Expected installed toolchain directory to still exist, but it has been deleted"
 fi
 
-# Attempt the same installation, but overwrite this time.
+test_log "Attempting the same installation (--overwrite flag is specified)"
 ./swiftly-install.sh -y --overwrite --no-install-system-deps
 
 if ! has_command "swiftly" ; then
@@ -65,6 +78,10 @@ fi
 
 if [[ -d "$SWIFTLY_HOME_DIR/toolchains/5.7.3" ]]; then
     test_fail "Expected installed toolchain directory to have been overwritten, but it still exists"
+fi
+
+if [ -L "$SWIFTLY_BIN_DIR/$dummy_executable_name" ]; then
+    test_fail "Expected symlink to have been deleted, but it still exists"
 fi
 
 swiftly --version

--- a/install/tests/overwrite.sh
+++ b/install/tests/overwrite.sh
@@ -32,7 +32,7 @@ echo "$DUMMY_CONFIG_CONTENTS" > "$SWIFTLY_HOME_DIR/config.json"
 mkdir "$SWIFTLY_HOME_DIR/toolchains/5.7.3"
 
 # Attempt the same installation, but decline to overwrite.
-printf "1\nn\n" | ./swiftly-install.sh
+./swiftly-install.sh -y --no-install-system-deps
 
 if ! has_command "swiftly" ; then
     test_fail "Can't find swiftly on the PATH"
@@ -48,7 +48,7 @@ if [[ ! -d "$SWIFTLY_HOME_DIR/toolchains/5.7.3" ]]; then
 fi
 
 # Attempt the same installation, but overwrite this time.
-printf "1\ny\n" | ./swiftly-install.sh --no-install-system-deps
+./swiftly-install.sh -y --overwrite --no-install-system-deps
 
 if ! has_command "swiftly" ; then
     test_fail "Can't find swiftly on the PATH"

--- a/install/tests/platform-option.sh
+++ b/install/tests/platform-option.sh
@@ -17,7 +17,7 @@ trap cleanup EXIT
 platforms=("ubuntu22.04" "ubuntu20.04" "ubuntu18.04" "amazonlinux2" "rhel9")
 
 for platform in "${platforms[@]}"; do
-    ./swiftly-install.sh --disable-confirmation --no-install-system-deps --platform "$platform"
+    ./swiftly-install.sh --overwrite --disable-confirmation --no-install-system-deps --platform "$platform"
     cat $HOME/.local/share/swiftly/config.json
 
     if [[ "$platform" == "rhel9" ]]; then

--- a/install/tests/update-bash-profile.sh
+++ b/install/tests/update-bash-profile.sh
@@ -34,7 +34,7 @@ if [[ "$(cat $HOME/.bash_login)" != "" ]]; then
 fi
 
 rm "$HOME/.bash_profile"
-printf "1\ny\n" | ./swiftly-install.sh --no-install-system-deps
+./swiftly-install.sh -y --overwrite --no-install-system-deps
 
 if [[ -f "$HOME/.bash_profile" ]]; then
    test_fail "install created .bash_profile when it should not have"


### PR DESCRIPTION
Closes #83, also fixes #82

This PR updates the default behavior of swiftly-install.sh when an existing installation exists from prompting to perform a clean installation (i.e. delete all existing configuration and installed toolchains) to simply replacing the swiftly binary. Users can opt into the old behavior (without prompting) by using a newly introduced `--overwrite` option.

Going forward, most users will update swiftly via the `self-update` command introduced in #81, but since the current released swiftly version doesn't have that command, I think we need to provide a path through `swiftly-install.sh`. Furthermore, it would be too easy to accidentally delete your swiftly installation with the old default behavior, given that there isn't another supported means of upgrading.

Once this is done,  I think I'm good to go ahead with releasing 0.2.0 of swiftly (and 0.3.0 of swiftly-install.sh).