### PR TITLE
"swiftly uninstall all" command to remove all installed toolchains

### DIFF
--- a/Sources/Swiftly/Uninstall.swift
+++ b/Sources/Swiftly/Uninstall.swift
@@ -33,6 +33,10 @@ struct Uninstall: SwiftlyCommand {
         The latest installed stable release can be uninstalled by specifying  'latest':
 
             $ swiftly uninstall latest
+
+        Finally, all installed toolchains can be uninstalled by specifying 'all':
+
+            $ swiftly uninstall all
         """
     ))
     var toolchain: String
@@ -44,7 +48,11 @@ struct Uninstall: SwiftlyCommand {
     var assumeYes: Bool = false
 
     mutating func run() async throws {
-        let selector = try ToolchainSelector(parsing: self.toolchain)
+        let selector: ToolchainSelector? = if self.toolchain != "all" {
+            try ToolchainSelector(parsing: self.toolchain)
+        } else {
+            nil // a nil selector causes listInstalledToolchains to return all toolchains, which is what we want
+        }
         let startingConfig = try Config.load()
         let toolchains = startingConfig.listInstalledToolchains(selector: selector)
 

--- a/Tests/SwiftlyTests/UninstallTests.swift
+++ b/Tests/SwiftlyTests/UninstallTests.swift
@@ -283,4 +283,17 @@ final class UninstallTests: SwiftlyTests {
             )
         }
     }
+
+    /// Tests that providing "all" as an argument to uninstall will uninstall all toolchains.
+    func testUninstallAll() async throws {
+        let toolchains = Set([Self.oldStable, Self.newStable, Self.newMainSnapshot, Self.oldReleaseSnapshot])
+        try await self.withMockedHome(homeName: Self.homeName, toolchains: toolchains, inUse: Self.newMainSnapshot) {
+            var uninstall = try self.parseCommand(Uninstall.self, ["uninstall", "-y", "all"])
+            _ = try await uninstall.run()
+            try await self.validateInstalledToolchains(
+                [],
+                description: "uninstall did not uninstall all toolchains"
+            )
+        }
+    }
 }


### PR DESCRIPTION
Hello, I maintain the [swiftly-bin AUR package](https://aur.archlinux.org/packages/swiftly-bin), and I appreciate all of the work that has gone into this utility, as it has been very useful to use (and definitely more flexible than just using the swift-bin AUR package!)

The [.install script](https://aur.archlinux.org/cgit/aur.git/tree/swiftly-bin.install?h=swiftly-bin) I wrote for said package runs `swiftly uninstall latest` in a loop until the `~/.local/share/swiftly/toolchains` folder is empty. This is prone to an infinite loop if a non-toolchain file or folder is placed in that directory.

To alleviate this, I propose some small changes to Uninstall.swift that allow for a one-command uninstallation of all installed toolchains with `swiftly uninstall all.`

I am new to contributing, so please let me know if there are any issues with this proposal.

Thank you!