### PR TITLE
fix: fix decoding error in `self-update` (#89)

### DIFF
--- a/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
+++ b/Sources/SwiftlyCore/HTTPClient+GitHubAPI.swift
@@ -4,6 +4,10 @@ import Foundation
 
 public struct SwiftlyGitHubRelease: Codable {
     public let tag: String
+
+    enum CodingKeys: String, CodingKey {
+        case tag = "tag_name"
+    }
 }
 
 extension SwiftlyHTTPClient {

--- a/Tests/SwiftlyTests/SelfUpdateTests.swift
+++ b/Tests/SwiftlyTests/SelfUpdateTests.swift
@@ -59,14 +59,25 @@ final class SelfUpdateTests: SwiftlyTests {
         }
     }
 
-    /// Verify updating the most up-to-date toolchain has no effect.
     func testSelfUpdate() async throws {
         try await self.runSelfUpdateTest(latestVersion: Self.newPatchVersion)
         try await self.runSelfUpdateTest(latestVersion: Self.newMinorVersion)
         try await self.runSelfUpdateTest(latestVersion: Self.newMajorVersion)
     }
 
+    /// Verify updating the most up-to-date toolchain has no effect.
     func testSelfUpdateAlreadyUpToDate() async throws {
         try await self.runSelfUpdateTest(latestVersion: String(describing: SwiftlyCore.version), shouldUpdate: false)
+    }
+
+    /// Tests that attempting to self-update using the actual GitHub API works as expected.
+    func testSelfUpdateIntegration() async throws {
+        try await self.withTestHome {
+            let swiftlyURL = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent("swiftly", isDirectory: false)
+            try "old".data(using: .utf8)!.write(to: swiftlyURL)
+
+            var update = try self.parseCommand(SelfUpdate.self, ["self-update"])
+            try await update.run()
+        }
     }
 }


### PR DESCRIPTION
fixes #89 

I'm not sure that this is in line with the design intent, but I confirm that the problem has been resolved.

```console
$ swift run swiftly self-update
Building for debugging...
Build complete! (0.35s)
Checking for swiftly updates...
Already up to date.
```