### PR TITLE
feat: support fish shell in swiftly-install.sh (#72)

### DIFF
--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -12,10 +12,11 @@
 # to store platform information, downloaded toolchains, and other state required to manage
 # the toolchains.
 #
-# After installation, the script will create $SWIFTLY_HOME_DIR/env.sh, which can be sourced
+# After installation, the script will create $SWIFTLY_HOME_DIR/env.{sh,fish}, which can be sourced
 # to properly set up the environment variables required to run swiftly. Unless --no-modify-profile
-# was specified, the script will also update ~/.profile, ~/.bash_profile, ~/.bash_login, or ~/.zprofile,
-# depending on the value of $SHELL and the existence of the files, to source the env.sh file on login.
+# was specified, the script will also update ~/.profile, ~/.bash_profile, ~/.bash_login, ~/.zprofile,
+# $XDG_CONFIG_HOME/fish/conf.d/swiftly.fish, or ~/.config/fish/conf.d/swiftly.fish depending on
+# the value of $SHELL and the existence of the files, to source the env.{sh,fish} file on login.
 # This will ensure that future logins will automatically configure SWIFTLY_HOME_DIR, SWIFTLY_BIN_DIR,
 # and PATH.
 #
@@ -486,6 +487,15 @@ case "$SHELL" in
             PROFILE_FILE="$HOME/.bash_login"
         fi
         ;;
+    *"fish")
+        # $XDG_CONFIG_HOME/fish/conf.d/swiftly.fish or ~/.config/fish/conf.d/swiftly.fish
+        # https://github.com/fish-shell/fish-shell/issues/3170#issuecomment-228311857
+        if [ -n "$XDG_CONFIG_HOME" ]; then
+            PROFILE_FILE="$XDG_CONFIG_HOME/fish/conf.d/swiftly.fish"
+        else
+            PROFILE_FILE="$HOME/.config/fish/conf.d/swiftly.fish"
+        fi
+        ;;
     *)
 esac
 
@@ -570,25 +580,41 @@ curl \
 
 chmod +x "$BIN_DIR/swiftly"
 
-if [[ "$detected_existing_installation" != "true" || "$overwrite_existing_intallation" == "true" ]]; then
-    echo "$JSON_OUT" > "$HOME_DIR/config.json"
-
-    # Verify the downloaded executable works. The script will exit if this fails due to errexit.
-    SWIFTLY_HOME_DIR="$HOME_DIR" SWIFTLY_BIN_DIR="$BIN_DIR" "$BIN_DIR/swiftly" --version > /dev/null
-
-    ENV_OUT=$(cat <<EOF
+case "$SHELL" in
+    *"fish")
+        ENV_OUT=$(cat <<EOF
+set -x SWIFTLY_HOME_DIR "$(replace_home_path $HOME_DIR)"
+set -x SWIFTLY_BIN_DIR "$(replace_home_path $BIN_DIR)"
+if not contains "\$SWIFTLY_BIN_DIR" \$PATH
+   set -x PATH "\$SWIFTLY_BIN_DIR" \$PATH
+end
+EOF
+               )
+        ENV_FILE="env.fish"
+        ;;
+    *)
+        ENV_OUT=$(cat <<EOF
 export SWIFTLY_HOME_DIR="$(replace_home_path $HOME_DIR)"
 export SWIFTLY_BIN_DIR="$(replace_home_path $BIN_DIR)"
 if [[ ":\$PATH:" != *":\$SWIFTLY_BIN_DIR:"* ]]; then
    export PATH="\$SWIFTLY_BIN_DIR:\$PATH"
 fi
 EOF
-           )
+               )
+        ENV_FILE="env.sh"
+        ;;
+esac
 
-    echo "$ENV_OUT" > "$HOME_DIR/env.sh"
+if [[ "$detected_existing_installation" != "true" || "$overwrite_existing_intallation" == "true" ]]; then
+    echo "$JSON_OUT" > "$HOME_DIR/config.json"
+
+    # Verify the downloaded executable works. The script will exit if this fails due to errexit.
+    SWIFTLY_HOME_DIR="$HOME_DIR" SWIFTLY_BIN_DIR="$BIN_DIR" "$BIN_DIR/swiftly" --version > /dev/null
+
+    echo "$ENV_OUT" > "$HOME_DIR/$ENV_FILE"
 
     if [[ "$MODIFY_PROFILE" == "true" ]]; then
-        SOURCE_LINE=". $(replace_home_path $HOME_DIR)/env.sh"
+        SOURCE_LINE=". $(replace_home_path $HOME_DIR)/$ENV_FILE"
 
         # Only append the line if it isn't in .profile already.
         if [[ ! -f "$PROFILE_FILE" ]] || [[ ! "$(cat $PROFILE_FILE)" =~ "$SOURCE_LINE" ]]; then
@@ -611,7 +637,7 @@ if ! has_command "swiftly" || [[ "$HOME_DIR" != "$DEFAULT_HOME_DIR" || "$BIN_DIR
     echo "Once you log in again, swiftly should be accessible from your PATH."
     echo "To begin using swiftly from your current shell, first run the following command:"
     echo ""
-    echo "    . $(replace_home_path $HOME_DIR)/env.sh"
+    echo "    . $(replace_home_path $HOME_DIR)/$ENV_FILE"
     echo ""
     echo "Then to install the latest version of Swift, run 'swiftly install latest'"
 else

--- a/install/tests/update-fish-config.sh
+++ b/install/tests/update-fish-config.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Tests that swiftly.fish is updated properly if the user's shell is fish.
+# WARNING: this test makes changes to the local filesystem and is intended to be run in a containerized environment.
+
+set -o errexit
+source ./test-util.sh
+
+cleanup () {
+    set +o errexit
+
+    rm "$HOME/.config/fish/conf.d/swiftly.fish"
+    rm "$HOME/.xdg/config/fish/conf.d/swiftly.fish"
+
+    rm -r "$HOME/.local/share/swiftly"
+    rm "$HOME/.local/bin/swiftly"
+}
+trap cleanup EXIT
+
+export SHELL="fish"
+
+mkdir -p "$HOME/.config/fish/conf.d"
+echo "1" | ./swiftly-install.sh --no-install-system-deps
+
+if [[ ! "$(cat $HOME/.config/fish/conf.d/swiftly.fish)" =~ "swiftly/env.fish" ]]; then
+   test_fail "install did not update ~/.config/fish/conf.d/swiftly.fish"
+fi
+
+export XDG_CONFIG_HOME="$HOME/.xdg/config"
+mkdir -p "$XDG_CONFIG_HOME/fish/conf.d"
+./swiftly-install.sh -y --overwrite --no-install-system-deps
+
+if [[ ! "$(cat $XDG_CONFIG_HOME/fish/conf.d/swiftly.fish)" =~ "swiftly/env.fish" ]]; then
+   test_fail "install did not update \$XDG_CONFIG_HOME/fish/conf.d/swiftly.fish"
+fi
+
+
+test_pass


### PR DESCRIPTION
resolves #72

I added support for fish to `swiftly-install.sh`.

I added a unit test and confirm that all tests have passed by running `docker compose up install-test`. And of course, I tested that I could run `swiftly` after clean installation on my real environment.