### PR TITLE
fix(install): use `source` instead of `.` in fish

### DIFF
--- a/install/swiftly-install.sh
+++ b/install/swiftly-install.sh
@@ -600,6 +600,7 @@ end
 EOF
                )
         ENV_FILE="env.fish"
+        SOURCE_LINE="source $(replace_home_path $HOME_DIR)/$ENV_FILE"
         ;;
     *)
         ENV_OUT=$(cat <<EOF
@@ -611,6 +612,7 @@ fi
 EOF
                )
         ENV_FILE="env.sh"
+        SOURCE_LINE=". $(replace_home_path $HOME_DIR)/$ENV_FILE"
         ;;
 esac
 
@@ -623,8 +625,6 @@ if [[ "$detected_existing_installation" != "true" || "$overwrite_existing_intall
     echo "$ENV_OUT" > "$HOME_DIR/$ENV_FILE"
 
     if [[ "$MODIFY_PROFILE" == "true" ]]; then
-        SOURCE_LINE=". $(replace_home_path $HOME_DIR)/$ENV_FILE"
-
         # Only append the line if it isn't in .profile already.
         if [[ ! -f "$PROFILE_FILE" ]] || [[ ! "$(cat $PROFILE_FILE)" =~ "$SOURCE_LINE" ]]; then
             echo "$SOURCE_LINE" >> "$PROFILE_FILE"
@@ -658,7 +658,7 @@ if ! has_command "swiftly" || [[ "$HOME_DIR" != "$DEFAULT_HOME_DIR" || "$BIN_DIR
     fi
     echo "To begin using swiftly from your current shell, first run the following command:"
     echo ""
-    echo "    . $(replace_home_path $HOME_DIR)/$ENV_FILE"
+    echo "    $SOURCE_LINE"
     echo ""
     echo "Then to install the latest version of Swift, run 'swiftly install latest'"
 else


### PR DESCRIPTION
fixes #104 

This is a follow-up pull request of #91.

This pull request doesn't contain changes for fish users who have already installed swiftly.

## Checks

I also checked output files and output messages in addition to `docker compose up install-test`.

```console
$ rm -rf ~/.local/bin/swiftly ~/.config/fish/conf.d/swiftly.fish ~/.local/share/swiftly
$ ./install/swiftly-install.sh --no-install-system-deps
Fedora Linux Asahi Remix 39 (Thirty Nine) is not an officially supported platform, but the toolchains for another platform may still work on it.

Please select the platform to use for toolchain downloads:
0) Cancel
1) Ubuntu 22.04
2) Ubuntu 20.04
3) Ubuntu 18.04
4) RHEL 9
5) Amazon Linux 2
> 1
This script will install swiftly, a Swift toolchain installer and manager.

Current installation options:

    Data and configuration files directory: $HOME/.local/share/swiftly
        Executables installation directory: $HOME/.local/bin
  Modify login config ($HOME/.config/fish/conf.d/swiftly.fish): true
               Install system dependencies: false

Select one of the following:
1) Proceed with the installation (default)
2) Customize the installation
3) Cancel
> 1
Downloading swiftly from https://github.com/swift-server/swiftly/releases/latest/download/swiftly-aarch64-unknown-linux-gnu...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 55.9M  100 55.9M    0     0  10.5M      0  0:00:05  0:00:05 --:--:-- 11.1M

Importing Swift's PGP keys...
gpg: key D441C977412B37AD: "Swift Automatic Signing Key #1 <swift-infrastructure@swift.org>" not changed
gpg: key 9F597F4D21A56D5F: "Swift 2.2 Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key 63BC1CFE91D306C6: "Swift 3.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key EF5430F071E1B235: "Swift 4.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key 7638F1FB2B2B08C4: "Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>" not changed
gpg: key 925CC1CCED3D1561: "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key FAF6989E1BC16FEA: "Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>" not changed
gpg: key 925CC1CCED3D1561: "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key F167DF1ACF9CE069: "Swift Automatic Signing Key #4 <swift-infrastructure@forums.swift.org>" not changed
gpg: key 925CC1CCED3D1561: "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>" not changed
gpg: key F167DF1ACF9CE069: "Swift Automatic Signing Key #4 <swift-infrastructure@forums.swift.org>" not changed
gpg: Total number processed: 11
gpg:              unchanged: 11

swiftly has been successfully installed!

Once you log in again, swiftly should be accessible from your PATH.
To begin using swiftly from your current shell, first run the following command:

    source $HOME/.local/share/swiftly/env.fish

Then to install the latest version of Swift, run 'swiftly install latest'
$ cat ~/.config/fish/conf.d/swiftly.fish
source $HOME/.local/share/swiftly/env.fish
```