### PR TITLE
improve API usages around String/Data/ByteBuffer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "swiftly",
+    platforms: [.macOS(.v13)],
     products: [
         .executable(
             name: "swiftly",

--- a/Sources/Swiftly/List.swift
+++ b/Sources/Swiftly/List.swift
@@ -70,7 +70,7 @@ struct List: SwiftlyCommand {
 
             let message = "Installed \(modifier) toolchains"
             SwiftlyCore.print(message)
-            SwiftlyCore.print(String(repeating: "-", count: message.utf8.count))
+            SwiftlyCore.print(String(repeating: "-", count: message.count))
             for toolchain in toolchains {
                 printToolchain(toolchain)
             }

--- a/Sources/Swiftly/ListAvailable.swift
+++ b/Sources/Swiftly/ListAvailable.swift
@@ -91,7 +91,7 @@ struct ListAvailable: SwiftlyCommand {
 
             let message = "Available \(modifier) toolchains"
             SwiftlyCore.print(message)
-            SwiftlyCore.print(String(repeating: "-", count: message.utf8.count))
+            SwiftlyCore.print(String(repeating: "-", count: message.count))
             for toolchain in toolchains {
                 printToolchain(toolchain)
             }

--- a/Sources/SwiftlyCore/HTTPClient.swift
+++ b/Sources/SwiftlyCore/HTTPClient.swift
@@ -65,9 +65,8 @@ public struct SwiftlyHTTPClient {
 
         guard case .ok = response.status else {
             var message = "received status \"\(response.status)\" when reaching \(url)"
-            if let json = response.buffer.getString(at: 0, length: response.buffer.readableBytes) {
-                message += ": \(json)"
-            }
+            let json = String(buffer: response.buffer)
+            message += ": \(json)"
             throw Error(message: message)
         }
 
@@ -186,9 +185,5 @@ public struct SwiftlyHTTPClient {
 }
 
 private class HTTPClientWrapper {
-    fileprivate let inner = HTTPClient(eventLoopGroupProvider: .singleton)
-
-    deinit {
-        try? self.inner.syncShutdown()
-    }
+    fileprivate let inner = HTTPClient.shared
 }

--- a/Tests/SwiftlyTests/SelfUpdateTests.swift
+++ b/Tests/SwiftlyTests/SelfUpdateTests.swift
@@ -31,8 +31,7 @@ final class SelfUpdateTests: SwiftlyTests {
                 try buffer.writeJSONEncodable(nextRelease)
                 return HTTPClientResponse(body: .bytes(buffer))
             case "github.com":
-                var buffer = ByteBuffer()
-                buffer.writeString(latestVersion)
+                let buffer = ByteBuffer(string: latestVersion)
                 return HTTPClientResponse(body: .bytes(buffer))
             default:
                 throw SwiftlyTestError(message: "unknown url host: \(String(describing: url.host))")
@@ -43,7 +42,7 @@ final class SelfUpdateTests: SwiftlyTests {
     func runSelfUpdateTest(latestVersion: String, shouldUpdate: Bool = true) async throws {
         try await self.withTestHome {
             let swiftlyURL = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent("swiftly", isDirectory: false)
-            try "old".data(using: .utf8)!.write(to: swiftlyURL)
+            try Data("old".utf8).write(to: swiftlyURL)
 
             var update = try self.parseCommand(SelfUpdate.self, ["self-update"])
             update.httpClient = Self.makeMockHTTPClient(latestVersion: latestVersion)
@@ -52,9 +51,9 @@ final class SelfUpdateTests: SwiftlyTests {
             let swiftly = try Data(contentsOf: swiftlyURL)
 
             if shouldUpdate {
-                XCTAssertEqual(String(data: swiftly, encoding: .utf8), latestVersion)
+                XCTAssertEqual(String(decoding: swiftly, as: UTF8.self), latestVersion)
             } else {
-                XCTAssertEqual(String(data: swiftly, encoding: .utf8), "old")
+                XCTAssertEqual(String(decoding: swiftly, as: UTF8.self), "old")
             }
         }
     }
@@ -74,7 +73,7 @@ final class SelfUpdateTests: SwiftlyTests {
     func testSelfUpdateIntegration() async throws {
         try await self.withTestHome {
             let swiftlyURL = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent("swiftly", isDirectory: false)
-            try "old".data(using: .utf8)!.write(to: swiftlyURL)
+            try Data("old".utf8).write(to: swiftlyURL)
 
             var update = try self.parseCommand(SelfUpdate.self, ["self-update"])
             try await update.run()

--- a/Tests/SwiftlyTests/SwiftlyTests.swift
+++ b/Tests/SwiftlyTests/SwiftlyTests.swift
@@ -443,7 +443,7 @@ public struct MockToolchainDownloader: HTTPRequestExecutor {
             echo '\(toolchain.name)'
             """
 
-            let data = script.data(using: .utf8)!
+            let data = Data(script.utf8)
             try data.write(to: executablePath)
 
             // make the file executable

--- a/Tests/SwiftlyTests/UseTests.swift
+++ b/Tests/SwiftlyTests/UseTests.swift
@@ -230,7 +230,7 @@ final class UseTests: SwiftlyTests {
             // Add an unrelated executable to the binary directory.
             let existingFileName = "existing"
             let existingExecutableURL = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent(existingFileName)
-            let data = "hello world\n".data(using: .utf8)!
+            let data = Data("hello world\n".utf8)
             try data.write(to: existingExecutableURL)
 
             for (toolchain, files) in spec {
@@ -264,7 +264,7 @@ final class UseTests: SwiftlyTests {
             let existingText = "existing"
             for fileName in existingExecutables {
                 let existingExecutableURL = Swiftly.currentPlatform.swiftlyBinDir.appendingPathComponent(fileName)
-                let data = existingText.data(using: .utf8)!
+                let data = Data(existingText.utf8)
                 try data.write(to: existingExecutableURL)
             }
 


### PR DESCRIPTION
- fix `String(data:encoding)` to the better `String(decoding:as:)`
- fix `String.data(encoding:)` to the better `Data(string.utf8)`
- fix `ByteBuffer` conversion